### PR TITLE
Add support for MagicPython syntax highlighting

### DIFF
--- a/lib/docblock-python.js
+++ b/lib/docblock-python.js
@@ -120,7 +120,7 @@ export default {
 
     if (editor = atom.workspace.getActiveTextEditor()) {
       let language = editor.getGrammar().name;
-      if( language === 'Python') {
+      if(language === "Python" || language === "MagicPython") {
           editor.moveToFirstCharacterOfLine();
           var pos = editor.getCursorBufferPosition();
           var col = pos.column;
@@ -448,7 +448,7 @@ export default {
 
     if (editor = atom.workspace.getActiveTextEditor()) {
       let language = editor.getGrammar().name;
-      if( language === 'Python') {
+      if(language === "Python" || language === "MagicPython") {
         var current_docblock = this.get_docblock().split('\n');
         for (var i = 1; i <= current_docblock.length; i++) {
 

--- a/spec/docblock-python-spec.js
+++ b/spec/docblock-python-spec.js
@@ -17,7 +17,7 @@ describe('DocblockPython', () => {
     });
 
     waitsForPromise(() => {
-      return atom.packages.activatePackage('language-python')
+      return atom.packages.activatePackage('language-python') || atom.packages.activatePackage('MagicPython')
     });
 
   });


### PR DESCRIPTION
Hi @spadarian 

Nice package - this PR just adds support for Magic Python syntax highlighting (see: https://github.com/MagicStack/MagicPython)

Tested on my machine and works okay.

Cheers