### PR TITLE
#41: Add view to choose style

### DIFF
--- a/keymaps/docblock-python.json
+++ b/keymaps/docblock-python.json
@@ -1,5 +1,6 @@
 {
   "atom-workspace": {
-    "ctrl-alt-d": "docblock-python:generate_docblock"
+    "ctrl-alt-d": "docblock-python:generate_docblock",
+    "ctrl-alt-s": "docblock-python:choose_style"
   }
 }

--- a/lib/docblock-python-view.js
+++ b/lib/docblock-python-view.js
@@ -12,7 +12,7 @@ export default class StyleChooserView {
       elementForItem: (item) => {
         element = document.createElement('li');
         _internal = document.createElement('div');
-        primaryLine.classList.add('docblock-python');
+        _internal.classList.add('docblock-python');
         if (atom.config.get('docblock-python.style') == item ) {
           _internal.classList.add('.docblock-python-current-style');
         }

--- a/lib/docblock-python-view.js
+++ b/lib/docblock-python-view.js
@@ -14,7 +14,7 @@ export default class StyleChooserView {
         _internal = document.createElement('div');
         primaryLine.classList.add('docblock-python');
         if (atom.config.get('docblock-python.style') == item ) {
-          _internal.classList.add('current');
+          _internal.classList.add('.docblock-python-current-style');
         }
         _internal.appendChild(document.createTextNode(item));
         element.appendChild(_internal);

--- a/lib/docblock-python-view.js
+++ b/lib/docblock-python-view.js
@@ -1,75 +1,78 @@
 'use babel';
 /* eslint-disable require-jsdoc, no-invalid-this*/
-const SelectListView = require('atom-select-list')
+const SelectListView = require('atom-select-list');
 import templates from './templates.js';
 
 
 export default class StyleChooserView {
-
   constructor(serializedState) {
     // Create root element
     this.selectListView = new SelectListView({
       items: [],
       elementForItem: (item) => {
-        element = document.createElement('li')
-        _internal = document.createElement('div')
-        primaryLine.classList.add('docblock-python')
+        element = document.createElement('li');
+        _internal = document.createElement('div');
+        primaryLine.classList.add('docblock-python');
         if (atom.config.get('docblock-python.style') == item ) {
-          _internal.classList.add('current')
+          _internal.classList.add('current');
         }
-        _internal.appendChild(document.createTextNode(item))
-        element.appendChild(_internal)
-        return element
+        _internal.appendChild(document.createTextNode(item));
+        element.appendChild(_internal);
+        return element;
       },
       didConfirmSelection: (item) => {
-        atom.config.set('docblock-python.style', item)
-        this.cancel()
+        atom.config.set('docblock-python.style', item);
+        this.cancel();
       },
-      didCancelSelection: () => { this.cancel() },
-      didConfirmEmptySelection: () => { this.cancel() },
-    })
-    this.selectListView.element.classList.add('docblock-python')
+      didCancelSelection: () => {
+        this.cancel();
+      },
+      didConfirmEmptySelection: () => {
+        this.cancel();
+      },
+    });
+    this.selectListView.element.classList.add('docblock-python');
   }
 
-  get element () {
-    return this.selectListView.element
+  get element() {
+    return this.selectListView.element;
   }
 
   getItems() {
-    var keys = Object.keys(templates);
-    return keys
+    let keys = Object.keys(templates);
+    return keys;
   }
 
-  destroy () {
+  destroy() {
     if (this.panel) {
-      this.panel.destroy()
+      this.panel.destroy();
     }
-    return this.selectListView.destroy()
+    return this.selectListView.destroy();
   }
 
-  cancel () {
-    this.selectListView.reset()
-    this.hide()
+  cancel() {
+    this.selectListView.reset();
+    this.hide();
   }
 
-  show () {
-    this.previouslyFocusedElement = document.activeElement
+  show() {
+    this.previouslyFocusedElement = document.activeElement;
     if (!this.panel) {
-      this.panel = atom.workspace.addModalPanel({item: this})
+      this.panel = atom.workspace.addModalPanel({item: this});
     }
-    this.selectListView.update({items: this.getItems()})
-    this.panel.show()
-    this.selectListView.focus()
+    this.selectListView.update({items: this.getItems()});
+    this.panel.show();
+    this.selectListView.focus();
   }
 
-  hide () {
+  hide() {
     if (this.panel) {
-      this.panel.hide()
+      this.panel.hide();
     }
 
     if (this.previouslyFocusedElement) {
-      this.previouslyFocusedElement.focus()
-      this.previouslyFocusedElement = null
+      this.previouslyFocusedElement.focus();
+      this.previouslyFocusedElement = null;
     }
   }
 }

--- a/lib/docblock-python-view.js
+++ b/lib/docblock-python-view.js
@@ -1,0 +1,77 @@
+'use babel';
+/* eslint-disable require-jsdoc, no-invalid-this*/
+
+const SelectListView = require('atom-select-list')
+
+import templates from './templates.js';
+
+
+export default class StyleChooserView {
+
+  constructor(serializedState) {
+    // Create root element
+    this.selectListView = new SelectListView({
+      items: [],
+      elementForItem: (item) => {
+        element = document.createElement('li')
+
+        primaryLine = document.createElement('div')
+        if (atom.config.get('docblock-python.style') == item ) {
+          primaryLine.classList.add('docblock-python-current')
+        } else {
+          primaryLine.classList.add('docblock-python')
+        }
+        primaryLine.appendChild(document.createTextNode(item))
+        element.appendChild(primaryLine)
+        return element
+      },
+      didConfirmSelection: (item) => {
+        atom.config.set('docblock-python.style', item)
+        this.cancel()
+      },
+    })
+    this.selectListView.element.classList.add('docblock-python')
+  }
+
+  get element () {
+    return this.selectListView.element
+  }
+
+  getItems() {
+    var keys = Object.keys(templates);
+    return keys
+  }
+
+  destroy () {
+    if (this.panel) {
+      this.panel.destroy()
+    }
+    return this.selectListView.destroy()
+  }
+
+  cancel () {
+    this.selectListView.reset()
+    this.hide()
+  }
+
+  show () {
+    this.previouslyFocusedElement = document.activeElement
+    if (!this.panel) {
+      this.panel = atom.workspace.addModalPanel({item: this})
+    }
+    this.selectListView.update({items: this.getItems()})
+    this.panel.show()
+    this.selectListView.focus()
+  }
+
+  hide () {
+    if (this.panel) {
+      this.panel.hide()
+    }
+
+    if (this.previouslyFocusedElement) {
+      this.previouslyFocusedElement.focus()
+      this.previouslyFocusedElement = null
+    }
+  }
+}

--- a/lib/docblock-python-view.js
+++ b/lib/docblock-python-view.js
@@ -14,7 +14,7 @@ export default class StyleChooserView {
         _internal = document.createElement('div');
         _internal.classList.add('docblock-python');
         if (atom.config.get('docblock-python.style') == item ) {
-          _internal.classList.add('.docblock-python-current-style');
+          _internal.classList.add('docblock-python-current-style');
         }
         _internal.appendChild(document.createTextNode(item));
         element.appendChild(_internal);

--- a/lib/docblock-python-view.js
+++ b/lib/docblock-python-view.js
@@ -1,8 +1,6 @@
 'use babel';
 /* eslint-disable require-jsdoc, no-invalid-this*/
-
 const SelectListView = require('atom-select-list')
-
 import templates from './templates.js';
 
 
@@ -14,21 +12,21 @@ export default class StyleChooserView {
       items: [],
       elementForItem: (item) => {
         element = document.createElement('li')
-
-        primaryLine = document.createElement('div')
+        _internal = document.createElement('div')
+        primaryLine.classList.add('docblock-python')
         if (atom.config.get('docblock-python.style') == item ) {
-          primaryLine.classList.add('docblock-python-current')
-        } else {
-          primaryLine.classList.add('docblock-python')
+          _internal.classList.add('current')
         }
-        primaryLine.appendChild(document.createTextNode(item))
-        element.appendChild(primaryLine)
+        _internal.appendChild(document.createTextNode(item))
+        element.appendChild(_internal)
         return element
       },
       didConfirmSelection: (item) => {
         atom.config.set('docblock-python.style', item)
         this.cancel()
       },
+      didCancelSelection: () => { this.cancel() },
+      didConfirmEmptySelection: () => { this.cancel() },
     })
     this.selectListView.element.classList.add('docblock-python')
   }

--- a/lib/docblock-python.js
+++ b/lib/docblock-python.js
@@ -160,8 +160,8 @@ function activate(state) {
 
   // Add view provider
   atom.views.addViewProvider(() => {
-      return new StyleChooserView(state.StyleChooserViewState).element;
-    })
+    return new StyleChooserView(state.StyleChooserViewState).element;
+  });
 
   // Register command that toggles this view
   this.subscriptions.add(atom.commands.add('atom-workspace', {
@@ -169,12 +169,12 @@ function activate(state) {
     'docblock-python:choose_style': () => {
       if (this.stylechooser.panel) {
         if (this.stylechooser.panel.isVisible()) {
-          this.stylechooser.hide()
+          this.stylechooser.hide();
         } else {
-          this.stylechooser.show()
+          this.stylechooser.show();
         }
       } else {
-        this.stylechooser.show()
+        this.stylechooser.show();
       }
     },
   //   'docblock-python:add_section_notes': () => this.add_section_notes(),
@@ -1014,5 +1014,5 @@ export default {
   add_section_notes,
   generate_docblock,
   getFunctionReturnType,
-  serialize, activate, deactivate
+  serialize, activate, deactivate,
 };

--- a/lib/docblock-python.js
+++ b/lib/docblock-python.js
@@ -6,6 +6,7 @@ import packageConfig from './config.json';
 import templates from './templates.js';
 import {formatLint, lint_def, get_class_init, get_missing_attr,
   lint_docblocks, getStyledParam} from './linter-docblock-python.js';
+import StyleChooserView from './docblock-python-view.js';
 
 const main = {
   config: packageConfig,
@@ -155,13 +156,27 @@ function activate(state) {
   // Events subscribed to in atom's system can be easily cleaned up with a
   // CompositeDisposable
   this.subscriptions = new CompositeDisposable();
+  this.stylechooser = new StyleChooserView(state.StyleChooserViewState);
+
+  // Add view provider
+  atom.views.addViewProvider(() => {
+      return new StyleChooserView(state.StyleChooserViewState).element;
+    })
 
   // Register command that toggles this view
   this.subscriptions.add(atom.commands.add('atom-workspace', {
     'docblock-python:generate_docblock': () => this.generate_docblock(),
-    'docblock-python:numpy': () => this.set_style("numpy"),
-    'docblock-python:sphinx': () => this.set_style("sphinx"),
-    'docblock-python:google': () => this.set_style("google"),
+    'docblock-python:choose_style': () => {
+      if (this.stylechooser.panel) {
+        if (this.stylechooser.panel.isVisible()) {
+          this.stylechooser.hide()
+        } else {
+          this.stylechooser.show()
+        }
+      } else {
+        this.stylechooser.show()
+      }
+    },
   //   'docblock-python:add_section_notes': () => this.add_section_notes(),
   }));
 }
@@ -969,15 +984,6 @@ function add_section_notes() {
   };
 }
 
-function set_style(style) {
-  // Set docblock style.
-  if (style in templates) {
-    atom.config.set('docblock-python.style', style)
-  } else {
-    console.log('Undefined style.')
-  }
-}
-
 export default {
   ...main,
   format_lines,
@@ -1008,5 +1014,5 @@ export default {
   add_section_notes,
   generate_docblock,
   getFunctionReturnType,
-  serialize, activate, deactivate, set_style
+  serialize, activate, deactivate
 };

--- a/lib/docblock-python.js
+++ b/lib/docblock-python.js
@@ -159,6 +159,9 @@ function activate(state) {
   // Register command that toggles this view
   this.subscriptions.add(atom.commands.add('atom-workspace', {
     'docblock-python:generate_docblock': () => this.generate_docblock(),
+    'docblock-python:numpy': () => this.set_style("numpy"),
+    'docblock-python:sphinx': () => this.set_style("sphinx"),
+    'docblock-python:google': () => this.set_style("google"),
   //   'docblock-python:add_section_notes': () => this.add_section_notes(),
   }));
 }
@@ -966,6 +969,15 @@ function add_section_notes() {
   };
 }
 
+function set_style(style) {
+  // Set docblock style.
+  if (style in templates) {
+    atom.config.set('docblock-python.style', style)
+  } else {
+    console.log('Undefined style.')
+  }
+}
+
 export default {
   ...main,
   format_lines,
@@ -996,5 +1008,5 @@ export default {
   add_section_notes,
   generate_docblock,
   getFunctionReturnType,
-  serialize, activate, deactivate,
+  serialize, activate, deactivate, set_style
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1"
+        "acorn": "^5.0.3"
       }
     },
     "ajv": {
@@ -25,10 +25,10 @@
       "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.1"
       }
     },
     "ajv-keywords": {
@@ -61,7 +61,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-union": {
@@ -70,7 +70,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -90,10 +90,10 @@
       "resolved": "https://registry.npmjs.org/atom-linter/-/atom-linter-10.0.0.tgz",
       "integrity": "sha1-0nu3Tl+PCKdKQL6ynuGlDZdUPIk=",
       "requires": {
-        "named-js-regexp": "1.3.5",
-        "sb-exec": "4.0.0",
-        "sb-promisify": "2.0.2",
-        "tmp": "0.0.33"
+        "named-js-regexp": "^1.3.1",
+        "sb-exec": "^4.0.0",
+        "sb-promisify": "^2.0.1",
+        "tmp": "~0.0.28"
       }
     },
     "atom-package-deps": {
@@ -101,9 +101,9 @@
       "resolved": "https://registry.npmjs.org/atom-package-deps/-/atom-package-deps-4.6.2.tgz",
       "integrity": "sha512-GOcCULZPzpcFfnHo9Oz5fT/EaArFHNs84E4rp/Nox0/GlS1UYkEF44FRdgD+7TxAudRfQAXE0a8wh0GealCXZg==",
       "requires": {
-        "atom-package-path": "1.1.0",
-        "sb-fs": "3.0.0",
-        "semver": "5.5.0"
+        "atom-package-path": "^1.1.0",
+        "sb-fs": "^3.0.0",
+        "semver": "^5.3.0"
       }
     },
     "atom-package-path": {
@@ -111,7 +111,16 @@
       "resolved": "https://registry.npmjs.org/atom-package-path/-/atom-package-path-1.1.0.tgz",
       "integrity": "sha1-tR/tvADnyM5SI9DYA9t6P09pYU8=",
       "requires": {
-        "sb-callsite": "1.1.2"
+        "sb-callsite": "^1.1.2"
+      }
+    },
+    "atom-select-list": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/atom-select-list/-/atom-select-list-0.7.2.tgz",
+      "integrity": "sha512-a707OB1DhLGjzqtFrtMQKH7BBxFuCh8UBoUWxgFOrLrSwVh3g+/TlVPVDOz12+U0mDu3mIrnYLqQyhywQOTxhw==",
+      "requires": {
+        "etch": "^0.12.6",
+        "fuzzaldrin": "^2.1.0"
       }
     },
     "babel-code-frame": {
@@ -120,9 +129,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -131,11 +140,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -144,7 +153,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -161,7 +170,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -171,7 +180,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -186,9 +195,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -197,7 +206,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.2"
+            "color-convert": "^1.9.0"
           }
         },
         "supports-color": {
@@ -206,7 +215,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -229,7 +238,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -264,7 +273,7 @@
       "resolved": "https://registry.npmjs.org/consistent-env/-/consistent-env-1.3.1.tgz",
       "integrity": "sha1-9oI018afxt2WVviuI0Kc4EmbZfs=",
       "requires": {
-        "lodash.uniq": "4.5.0"
+        "lodash.uniq": "^4.5.0"
       }
     },
     "cross-spawn": {
@@ -273,11 +282,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.4",
-        "path-key": "2.0.1",
-        "semver": "5.5.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "debug": {
@@ -301,8 +310,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.12"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "del": {
@@ -311,13 +320,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "doctrine": {
@@ -326,7 +335,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "es-abstract": {
@@ -335,11 +344,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -348,9 +357,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -365,44 +374,44 @@
       "integrity": "sha512-D5nG2rErquLUstgUaxJlWB5+gu+U/3VDY0fk/Iuq8y9CUFy/7Y6oF4N2cR1tV8knzQvciIbfqfohd359xTLIKQ==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.4.1",
-        "cross-spawn": "6.0.5",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "4.0.0",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "4.0.0",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.7.0",
-        "ignore": "3.3.10",
-        "imurmurhash": "0.1.4",
-        "inquirer": "5.2.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.12.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "string.prototype.matchall": "2.0.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.3",
-        "text-table": "0.2.0"
+        "ajv": "^6.5.0",
+        "babel-code-frame": "^6.26.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^4.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.5.0",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^5.2.0",
+        "is-resolvable": "^1.1.0",
+        "js-yaml": "^3.11.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.1.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.0",
+        "string.prototype.matchall": "^2.0.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^4.0.3",
+        "text-table": "^0.2.0"
       }
     },
     "eslint-config-google": {
@@ -417,8 +426,8 @@
       "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -433,8 +442,8 @@
       "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1",
-        "acorn-jsx": "4.1.1"
+        "acorn": "^5.6.0",
+        "acorn-jsx": "^4.1.1"
       }
     },
     "esprima": {
@@ -449,7 +458,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -458,7 +467,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -473,15 +482,20 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "etch": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/etch/-/etch-0.12.8.tgz",
+      "integrity": "sha512-dFLRe4wLroVtwzyy1vGlE3BSDZHiL0kZME5XgNGzZIULcYTvVno8vbiIleAesoKJmwWaxDTzG+4eppg2zk14JQ=="
+    },
     "external-editor": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.23",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "fast-deep-equal": {
@@ -508,7 +522,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -517,8 +531,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "flat-cache": {
@@ -527,10 +541,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "foreach": {
@@ -557,18 +571,23 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "fuzzaldrin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzaldrin/-/fuzzaldrin-2.1.0.tgz",
+      "integrity": "sha1-kCBMPi/appQbso0WZF1BgGOpDps="
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -583,12 +602,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -603,7 +622,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -612,7 +631,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -633,7 +652,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
@@ -654,8 +673,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -670,19 +689,19 @@
       "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.1.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rxjs": "5.5.11",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rxjs": "^5.5.2",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       }
     },
     "is-callable": {
@@ -715,7 +734,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -724,7 +743,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-promise": {
@@ -739,7 +758,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -777,8 +796,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "json-schema-traverse": {
@@ -799,8 +818,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -826,7 +845,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -891,7 +910,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -900,7 +919,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optionator": {
@@ -909,12 +928,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-tmpdir": {
@@ -958,7 +977,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pluralize": {
@@ -991,7 +1010,7 @@
       "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2"
+        "define-properties": "^1.1.2"
       }
     },
     "regexpp": {
@@ -1006,8 +1025,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -1022,8 +1041,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
@@ -1032,7 +1051,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -1041,7 +1060,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rxjs": {
@@ -1069,9 +1088,9 @@
       "resolved": "https://registry.npmjs.org/sb-exec/-/sb-exec-4.0.0.tgz",
       "integrity": "sha1-RnR/DfFiYmwW6/D+pCJFrRqoWco=",
       "requires": {
-        "consistent-env": "1.3.1",
-        "lodash.uniq": "4.5.0",
-        "sb-npm-path": "2.0.0"
+        "consistent-env": "^1.2.0",
+        "lodash.uniq": "^4.5.0",
+        "sb-npm-path": "^2.0.0"
       }
     },
     "sb-fs": {
@@ -1079,8 +1098,8 @@
       "resolved": "https://registry.npmjs.org/sb-fs/-/sb-fs-3.0.0.tgz",
       "integrity": "sha1-+9zdMBDoChuOJ0kM7zNgZJdCA7g=",
       "requires": {
-        "sb-promisify": "2.0.2",
-        "strip-bom-buf": "1.0.0"
+        "sb-promisify": "^2.0.1",
+        "strip-bom-buf": "^1.0.0"
       }
     },
     "sb-memoize": {
@@ -1093,8 +1112,8 @@
       "resolved": "https://registry.npmjs.org/sb-npm-path/-/sb-npm-path-2.0.0.tgz",
       "integrity": "sha1-D2zCzzcd68p9k27Xa31MPMHrPVg=",
       "requires": {
-        "sb-memoize": "1.0.2",
-        "sb-promisify": "2.0.2"
+        "sb-memoize": "^1.0.2",
+        "sb-promisify": "^2.0.1"
       }
     },
     "sb-promisify": {
@@ -1113,7 +1132,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -1134,7 +1153,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "sprintf-js": {
@@ -1149,8 +1168,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string.prototype.matchall": {
@@ -1159,11 +1178,11 @@
       "integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "regexp.prototype.flags": "1.2.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "regexp.prototype.flags": "^1.2.0"
       }
     },
     "strip-ansi": {
@@ -1172,7 +1191,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1188,7 +1207,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
       "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.1"
       }
     },
     "strip-json-comments": {
@@ -1215,12 +1234,12 @@
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.2",
-        "ajv-keywords": "3.2.0",
-        "chalk": "2.4.1",
-        "lodash": "4.17.10",
+        "ajv": "^6.0.1",
+        "ajv-keywords": "^3.0.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       }
     },
     "text-table": {
@@ -1240,7 +1259,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "type-check": {
@@ -1249,7 +1268,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "uri-js": {
@@ -1258,7 +1277,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "which": {
@@ -1267,7 +1286,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wordwrap": {
@@ -1288,7 +1307,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "atom-linter": "^10.0.0",
-    "atom-package-deps": "^4.0.1"
+    "atom-package-deps": "^4.0.1",
+    "atom-select-list": "^0.7.0"
   },
   "devDependencies": {
     "eslint": "^5.0.1",

--- a/styles/docblock-python.less
+++ b/styles/docblock-python.less
@@ -7,7 +7,7 @@
 .docblock-python {
 }
 
-.docblock-python-current {
+.current {
   font-weight: bold;
   color: @text-color-highlight
 }

--- a/styles/docblock-python.less
+++ b/styles/docblock-python.less
@@ -6,3 +6,8 @@
 
 .docblock-python {
 }
+
+.docblock-python-current {
+  font-weight: bold;
+  color: @text-color-highlight
+}

--- a/styles/docblock-python.less
+++ b/styles/docblock-python.less
@@ -7,7 +7,7 @@
 .docblock-python {
 }
 
-.current {
+.docblock-python-current-style {
   font-weight: bold;
   color: @text-color-highlight
 }


### PR DESCRIPTION
This PR adresses #41.

It adds a command that triggers a view to set the style. After pressing `ctrl-alt-s` (like `ctrl-alt-d` but `s` for style) a pop up, much like the `command-pallete` shows up with all the options that are present in the templates. It looks like this (at least for me, with material-ui).

![image](https://user-images.githubusercontent.com/35146819/73700889-937af800-46c6-11ea-8759-8c95d1747c63.png)

Here you can search for you choice or go up and down with the keyboard arrows.

![image](https://user-images.githubusercontent.com/35146819/73700922-bc02f200-46c6-11ea-8a40-8bf22e2d698e.png)

All in all it looks like this:

![out](https://user-images.githubusercontent.com/35146819/73701612-dccc4700-46c8-11ea-8d40-1166a7623a50.gif)

pd: In case you decide to merge, I recommend a squash because the initial commit is off and doesn't apply.