### PR TITLE
Removes `this` for compatability with pulsar

### DIFF
--- a/lib/linter-docblock-python.js
+++ b/lib/linter-docblock-python.js
@@ -3,7 +3,7 @@
 
 import {get_all_docblocks} from './docblock-python.js';
 
-this.get_all_docblocks = get_all_docblocks;
+get_all_docblocks = get_all_docblocks;
 
 function formatLint(msg_pos, par_name, par_type, editorPath) {
   let type_text;
@@ -158,7 +158,7 @@ function lint_docblocks() {
     return [];
   };
   if (editor = atom.workspace.getActiveTextEditor()) {
-    let allBlocks = this.get_all_docblocks();
+    let allBlocks = get_all_docblocks();
     let missing_par = [];
     if (allBlocks.length > 0) {
       let that = this;


### PR DESCRIPTION
This would address and fix issue #58. Tested on both my work laptop (Mac) and personal device (Ubuntu 20.04).